### PR TITLE
Smoke test workflow and delete redundant package.json

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,0 +1,25 @@
+name: Smoke Tests
+
+on:
+  push:
+    branches: [development]
+  pull_request:
+    branches: [development]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm install
+      - name: Run smoke tests
+        run: npm run smoke-test

--- a/package.json
+++ b/package.json
@@ -1,5 +1,0 @@
-{
-  "devDependencies": {
-    "semantic-release": "^23.0.0"
-  }
-}


### PR DESCRIPTION
Experimenting a smoke test workflow to automate smoke tests. But there was an error regarding the script not found, I believe it is because there's an extra package.json in the parent folder of smoke test script.