### PR TITLE
fix: modified CreateUserHandler to accept requestId as params  

### DIFF
--- a/back-end/src/app/adapter/Controllers/Handlers/CreateUserHandler.ts
+++ b/back-end/src/app/adapter/Controllers/Handlers/CreateUserHandler.ts
@@ -24,8 +24,6 @@ export class CreateUserHandler implements IRouteHandler<UserRequest | null> {
   private readonly _logger: ILogger = LoggerFactory.getLogger(CreateUserHandler.name);
   private readonly USERID_LENGTH: number = 8; 
   constructor(@inject(delay(() => UserRequestService)) private readonly _userRequestService: UserRequestService, @inject(delay(() => UserService)) private readonly _userService: UserService) {
-    // this._userRequestService = container.resolve(UserRequestService);
-    // this._userService = container.resolve(UserService);
   }
 
     
@@ -78,11 +76,11 @@ export class CreateUserHandler implements IRouteHandler<UserRequest | null> {
             res.status(400).send("Bad request: The request does not meet the required criteria");
           }
         } else {
-          this._logger.INFO(`Failed to retrieve ${req.body.requestId}, reqeust doesn't exist`);
+          this._logger.INFO(`Failed to retrieve ${req.params.requestId}, reqeust doesn't exist`);
           res.status(404).send("Request not found");
         }
       }).catch((err) => {
-        this._logger.ERROR(`Failed to retrieve ${req.body.requestId}, error occured: ${err}`);
+        this._logger.ERROR(`Failed to retrieve ${req.params.requestId}, error occured: ${err}`);
         res.status(500).send("Server failed to process request, please try again");
       });
     } else {
@@ -93,7 +91,7 @@ export class CreateUserHandler implements IRouteHandler<UserRequest | null> {
   }
 
   public async execute(req: Request): Promise<UserRequest | null> {
-    const requestId: number = Number(req.body.requestId); 
+    const requestId: number = Number(req.params.requestId); 
     const userRequest: Promise<UserRequest | null> = this._userRequestService.get(requestId); 
     return userRequest;
   }
@@ -115,10 +113,11 @@ export class CreateUserHandler implements IRouteHandler<UserRequest | null> {
     const request: Request = args[0];
     return (
       !nullOrUndefined(request.body) && 
+      !nullOrUndefined(request.params) &&
     !nullOrUndefined(request.body.approved) && 
-    !nullOrUndefined(request.body.requestId) &&
+    !nullOrUndefined(request.params.requestId) &&
     (typeof request.body.approved === "boolean" || request.body.approved === "true" || request.body.approved === "false") &&
-    !isNaN(Number(request.body.requestId))
+    !isNaN(Number(request.params.requestId))
     ); 
   };
 

--- a/back-end/src/tests/api_tests/apiCreateUser.test.ts
+++ b/back-end/src/tests/api_tests/apiCreateUser.test.ts
@@ -52,7 +52,8 @@ describe("Create User API Test /api/user/request", () => {
     jest.spyOn(UserSQLRepository.prototype, "create").mockImplementation(async (user1) => mockUserRepo.create(user1));
     jest.spyOn(UserRequestService.prototype, "get").mockImplementation(async () => userReq);
 
-    const response = await request(app).patch(`/api/user/request/${userReq.id}`).send({ approved: true, requestId: userReq.id }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    const requestId = userReq.id;
+    const response = await request(app).patch(`/api/user/request/${requestId}`).send({ approved: true }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
 
     expect(response.statusCode).toBe(200);
     expect(response.text).toContain("User successfully approved and created");
@@ -63,7 +64,8 @@ describe("Create User API Test /api/user/request", () => {
     jest.spyOn(UserRequestSQLRepository.prototype, "update").mockImplementation(async (userReq) => mockUserReqRepo.update(userReq));
     jest.spyOn(UserRequestService.prototype, "get").mockImplementation(async () => userReq);
 
-    const response = await request(app).patch(`/api/user/request/${userReq.id}`).send({ approved: false, requestId: userReq.id }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    const requestId = userReq.id;
+    const response = await request(app).patch(`/api/user/request/${requestId}`).send({ approved: false }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
 
     expect(response.statusCode).toBe(200);
     expect(response.text).toContain("Successfully updated user request status 1");
@@ -75,7 +77,8 @@ describe("Create User API Test /api/user/request", () => {
     jest.spyOn(UserRequestSQLRepository.prototype, "update").mockImplementation(async (userReq) => mockUserReqRepo.update(notSignupUserReq));
     jest.spyOn(UserRequestService.prototype, "get").mockImplementation(async () => notSignupUserReq);
 
-    const response = await request(app).patch(`/api/user/request/${userReq.id}`).send({ approved: false, requestId: notSignupUserReq.id }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    const requestId = notSignupUserReq.id;
+    const response = await request(app).patch(`/api/user/request/${requestId}`).send({ approved: false }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
 
     expect(response.statusCode).toBe(400);
     expect(response.text).toContain("Bad request: The request does not meet the required criteria");
@@ -87,7 +90,8 @@ describe("Create User API Test /api/user/request", () => {
     jest.spyOn(UserRequestSQLRepository.prototype, "update").mockImplementation(async (userReq) => mockUserReqRepo.update(decisionMadeUserReq));
     jest.spyOn(UserRequestService.prototype, "get").mockImplementation(async () => decisionMadeUserReq);
 
-    const response = await request(app).patch(`/api/user/request/${userReq.id}`).send({ approved: true, requestId: decisionMadeUserReq.id }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
+    const requestId = decisionMadeUserReq.id;
+    const response = await request(app).patch(`/api/user/request/${requestId}`).send({ approved: true }).set("Authorization", `Bearer ${ADMIN_TOKEN}`);
 
     expect(response.statusCode).toBe(400);
     expect(response.text).toContain("Bad request: The request does not meet the required criteria");
@@ -100,7 +104,8 @@ describe("Create User API Test /api/user/request", () => {
     jest.spyOn(UserRequestService.prototype, "get").mockImplementation(async () => decisionMadeUserReq);
     jest.spyOn(UserService.prototype, "get").mockImplementation(async () => user);
 
-    const response = await request(app).patch(`/api/user/request/${userReq.id}`).send({ approved: true, requestId: decisionMadeUserReq.id }).set("Authorization", `Bearer ${USER_TOKEN}`);
+    const requestId = decisionMadeUserReq.id;
+    const response = await request(app).patch(`/api/user/request/${requestId}`).send({ approved: true }).set("Authorization", `Bearer ${USER_TOKEN}`);
 
     expect(response.statusCode).toBe(403);
     expect(response.text).toContain("Unauthorized access, you do not have permissions!");

--- a/back-end/src/tests/unit_tests/CreateUserHandler.unit.test.ts
+++ b/back-end/src/tests/unit_tests/CreateUserHandler.unit.test.ts
@@ -50,7 +50,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should succeed with the status code 200 if the user insertion was successful", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true);
       jest.spyOn(handler, "execute").mockReturnValue(Promise.resolve(mockReq));
@@ -67,7 +67,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 404 if 'execute' was not successful in fetching the user request", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true);
       jest.spyOn(handler, "execute").mockReturnValue(Promise.resolve(null));
@@ -84,7 +84,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 500 if 'execute' throws an error in fetching the user request", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true);
       jest.spyOn(handler, "execute").mockReturnValue(Promise.reject(new Error("Error")));
@@ -101,7 +101,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 400 if request type was not SIGNUP", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq_not_SIGNUP.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq_not_SIGNUP.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true); 
       jest.spyOn(handler, "execute").mockReturnValue(Promise.resolve(mockReq_not_SIGNUP));
@@ -118,7 +118,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 400 if decision date was not null", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq_date_not_null.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq_date_not_null.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true); 
       jest.spyOn(handler, "execute").mockReturnValue(Promise.resolve(mockReq_date_not_null));
@@ -135,7 +135,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 500 if the request was not updated", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq.id } } as unknown as Request;
       mockReq.status = RequestStatusEnum.AWAITING;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true);
@@ -150,7 +150,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should succeed with the status code 200 if the rejected request was updated successfully", async() => {
-      const req: Request = { body: { approved: false, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: false }, params: { requestId: mockReq_date_not_null.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       jest.spyOn(handler, "validation").mockReturnValue(true);
       jest.spyOn(handler, "execute").mockReturnValue(Promise.resolve(mockReq_rejected));
@@ -164,7 +164,7 @@ describe("CreateUser and Modify Request", () => {
     });
 
     it("should fail with the status code 500 if the user insertion was not successful and the rollback to request status was successful", async() => {
-      const req: Request = { body: { approved: true, requestId: mockReq.id } } as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: mockReq.id } } as unknown as Request;
       const res: Response = { status: jest.fn().mockReturnThis(), send: jest.fn() } as unknown as Response;
       mockReq.status = RequestStatusEnum.AWAITING;
       jest.spyOn(handler, "validation").mockReturnValue(true);
@@ -182,67 +182,67 @@ describe("CreateUser and Modify Request", () => {
 
   describe("validation", () => {
     it("should return true if true approved status and an integer requestId is provided", () => {
-      const req: Request = { body: { approved: true, requestId: 12 } } as any as Request;
+      const req: Request = { body: { approved: true }, params: { requestId: 12 } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeTruthy();
     });
 
     it("should return true if false approved status and an integer requestId is provided", () => {
-      const req: Request = { body: { approved: false, requestId: 112 } } as any as Request;
+      const req: Request = { body: { approved: false }, params: { requestId: 102 } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeTruthy();
     });
 
     it("should return false if null approved status and an integer requestId is provided", () => {
-      const req: Request = { body: { approved: null, requestId: 12 } } as any as Request;
+      const req: Request = { body: { approved: null }, params: { requestId: 1212 } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if undefined approved status and an integer requestId is provided", () => {
-      const req: Request = { body: { approved: undefined, requestId: 12 } } as any as Request;
+      const req: Request = { body: { approved: undefined }, params: { requestId: 102 } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if boolean approved status and a non-int requestId is provided", () => {
-      const req: Request = { body: { approved: false, requestId: "NaN" } } as any as Request;
+      const req: Request = { body: { approved: false }, params: { requestId: "NaN" } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if boolean approved status and a null requestId is provided", () => {
-      const req: Request = { body: { approved: false, requestId: null } } as any as Request;
+      const req: Request = { body: { approved: false }, params: { requestId: null } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if boolean approved status and a undefined requestId is provided", () => {
-      const req: Request = { body: { approved: false, requestId: undefined } } as any as Request;
+      const req: Request = { body: { approved: false }, params: { requestId: undefined } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if null approved status and a null requestId is provided", () => {
-      const req: Request = { body: { approved: null, requestId: null } } as any as Request;
+      const req: Request = { body: { approved: null }, params: { requestId: null } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
     it("should return false if undefined approved status and a undefined requestId is provided", () => {
-      const req: Request = { body: { approved: undefined, requestId: undefined } } as any as Request;
+      const req: Request = { body: { approved: undefined }, params: { requestId: undefined } } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
-    it("should return false if undefined body is provided", () => {
-      const req: Request = { body: undefined } as any as Request;
+    it("should return false if undefined body and param is provided", () => {
+      const req: Request = { body: undefined, params: undefined } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });
 
-    it("should return false if null body is provided", () => {
-      const req: Request = { body: null } as any as Request;
+    it("should return false if null body and param is provided", () => {
+      const req: Request = { body: null, params: null } as unknown as Request;
       const result: boolean = handler.validation(req);
       expect(result).toBeFalsy();
     });


### PR DESCRIPTION
- modified `CreateUserHandler` to accept requestId as params instead of body
- updated unit and api tests to test the changes (all tests pass)     